### PR TITLE
[Workflow] 배포 플로우 이슈 수정

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Couch-Coders/9th-soccer-BE
-          path: ./be
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'


### PR DESCRIPTION
* runner 를 구동하는 환경에서 ./be 폴더에 checkout 하게 됨
* `CDNievas/heroku-action@v1.0` Action 내부적으로 git 을 컨트롤하는데, ./ 폴더는 git 이 받아져있지 않아서 이슈 발생